### PR TITLE
Merge test executions

### DIFF
--- a/examples/cypress-using-hooks.config.ts
+++ b/examples/cypress-using-hooks.config.ts
@@ -19,9 +19,9 @@ export default defineConfig({
       });
 
       on('after:run', async (results: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult) => {
-          await awesomeAfterHook();
-          zephyrAfterHook(results);
-        },
+        await awesomeAfterHook();
+        await zephyrAfterHook(results);
+      },
       );
     },
   },

--- a/examples/cypress.config.ts
+++ b/examples/cypress.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   reporterOptions: {
     projectKey: 'BRE',
     authorizationToken: process.env.ZEPHYR_AUTHORIZATION_TOKEN,
+    mergeSameTestExecutions: true,
   },
   e2e: {
     setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -9,7 +9,7 @@ class BaseReporter extends reporters.Base {
   constructor(runner: Runner, options: MochaOptions) {
     super(runner, options);
 
-    this.reporter = new Reporter(runner, options.reporterOptions.projectKey);
+    this.reporter = new Reporter(runner, options.reporterOptions);
     this.reporter.setupZephyrReporter();
   }
 }


### PR DESCRIPTION
When `mergeSameTestExecutions ` is true, the report would only contain one result per `testCaseKey` by aggregating results.